### PR TITLE
pull request to myself of stuff done after pairing

### DIFF
--- a/features/step_definitions/subject_code_steps.rb
+++ b/features/step_definitions/subject_code_steps.rb
@@ -178,11 +178,9 @@ Then(/^it should have the expected output$/) do
 end
 
 When(/^I run a HW3Grader$/) do
-  # prefix_path = '/home/adminuser/dev/rag/spec/fixtures/hw3'
   # Presumes process launched in rag/
   prefix_path = Dir.getwd + '/spec/fixtures/hw3'
   FileUtils.cp_r "#{prefix_path}/rottenpotatoes" , '/tmp/'
-
   #  args = ['-t', 'HW3Grader', '-a', '/path/to/app/', 'input.tar.gz', 'description.yml' ]
   args = [
       '-t',

--- a/lib/grader.rb
+++ b/lib/grader.rb
@@ -2,42 +2,32 @@ require './lib/auto_grader.rb'
 
 class Grader
 
+  # TODO Can we simply do: return Kernel.const_get(type).new(args).grade!
   def self.cli(args)
-    return self.help if args.length < 4
-    type = args[1] # TODO parse opts here, Kernel.const_get(type).format_cli
-    # Emulate rag/grade3
-    if type == 'HW3Grader'
-      working_dir = args[3]
-      # Set and restore ENV['BUNDLE_GEMFILE'] when run with 'bundle exec'.
-      # rag/grade3 set ENV['RAILS_ROOT']. It seems to do nothing. Related?
-      working_gemfile  = working_dir+'/Gemfile'
-      original_gemfile = Dir.getwd+'/Gemfile'
-      Dir.chdir(working_dir){
-        ENV['BUNDLE_GEMFILE'] = working_gemfile
-        autograder_args = HW3Grader.format_cli *args
-        g = AutoGrader.create *autograder_args
-        g.grade!
-        ENV['BUNDLE_GEMFILE'] = original_gemfile
-        return self.feedback g
-      }
-    else
-      args[2] = IO.read(args[2]) if type == 'WeightedRspecGrader'
-      g = AutoGrader.create('1', args[1] ,args[2] ,:spec => args[3])
-      g.grade!
-      return self.feedback g
+    return self.help if args.nil? || args.length < 4 || ! args[1] =~ /Grader/
+    original_dir = Dir.getwd
+    begin
+      if args[2] == '-a'
+        working_dir = args[3]
+        Dir.chdir(working_dir)
+        ENV['BUNDLE_GEMFILE'] = working_dir + '/Gemfile'
+      end
+      self.run_grader(args)
+    ensure
+      Dir.chdir original_dir
+      ENV['BUNDLE_GEMFILE'] = original_dir + '/Gemfile'
     end
   end
 
-  def self.feedback(g)
-    <<EndOfFeedback
-Score out of 100: #{g.normalized_score(100)}
----BEGIN rspec comments---
-#{'-'*80}
-#{g.comments}
-#{'-'*80}
----END rspec comments---
-EndOfFeedback
+  def self.run_grader(args)
+    type = args[1]
+    subclass = Kernel.const_get(type)
+    autograder_args = subclass.format_cli(*args)
+    g = AutoGrader.create(*autograder_args)
+    g.grade!
+    return subclass.feedback g
   end
+
   def self.help
     <<EndOfHelp
 Usage: #{$0} -t GraderType submission specfile.rb

--- a/lib/graders/feature_grader/hw3_grader.rb
+++ b/lib/graders/feature_grader/hw3_grader.rb
@@ -11,8 +11,21 @@ class HW3Grader < FeatureGrader
   def self.format_cli(t_option, type, a_option, base_app_path, archive, hw3_yml)
     spec_hash = {:description => hw3_yml}
     spec_hash[:mt] = @multithread
-    @base_app_path = base_app_path
+#    @@base_app_path = base_app_path #HW4Grader takes this from hw4.yml
     return @assignment_id, type, archive, spec_hash
+  end
+
+  ##TODO Add student work to standard solution, like HW4Grader
+  # TODO Can't see it handled it rag/grade3, so where is it currently done?
+  #def grade!
+  #end
+
+  def self.feedback(completed_grader)
+    g = completed_grader
+    score_max = 500
+    score_msg = "Score out of #{score_max}: #{g.normalized_score(score_max)}\n"
+    comments_msg = "---BEGIN cucumber comments---\n#{'-'*80}\n#{g.comments}\n#{'-'*80}\n---END cucumber comments---"
+    return comments_msg + score_msg
   end
 
 end

--- a/lib/graders/rspec_grader/rspec_grader.rb
+++ b/lib/graders/rspec_grader/rspec_grader.rb
@@ -28,4 +28,19 @@ class RspecGrader < AutoGrader
     @comments = runner.output
   end
 
+  @assignment_id = '1'
+  def self.format_cli(t_opt, type, answer, specs)
+    return [@assignment_id, type , answer, {:spec => specs}]
+  end
+
+  def self.feedback(g)
+    <<EndOfFeedback
+Score out of 100: #{g.normalized_score(100)}
+---BEGIN rspec comments---
+#{'-'*80}
+    #{g.comments}
+    #{'-'*80}
+---END rspec comments---
+EndOfFeedback
+  end
 end

--- a/lib/graders/rspec_grader/weighted_rspec_grader.rb
+++ b/lib/graders/rspec_grader/weighted_rspec_grader.rb
@@ -1,6 +1,12 @@
 require_relative 'rspec_grader'
 
 class WeightedRspecGrader < RspecGrader
+
+  def self.format_cli(t_option, type, answer, specs)
+    answer = IO.read answer
+    return super(t_option, type, answer, specs)
+  end
+
   def grade!
     runner =  RspecRunner.new(@code, @specfile)
     runner.run


### PR DESCRIPTION
Streamlined grader, moved more feedback out into autograder subclasses. May as well do grade!() as well and just call Kernel.const_get(type).grade!(args) in Grader, get rid of AutoGrader for the most part?
