### PR TITLE
show Travis s3 pull request passes vs saasbook/rag develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ bundler_args: --without development --path=~/.bundle
 before_install:
 - 'echo ''gem: --no-ri --no-rdoc'' > ~/.gemrc'
 - gem install bundler bundle_cache
-- bundle config build.nokogiri --use-system-libraries
+#- bundle config build.nokogiri --use-system-libraries
 - bundle_cache_install
 script:
 - bundle exec rspec spec


### PR DESCRIPTION
- because travis doesn't allow secure env vars in pull requests
- see pull request https://github.com/saasbook/rag/pull/42
